### PR TITLE
Upd: Make sure we use python 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Install swagger-fuzzer via pip:
 
 .. code:: shell
 
-    pip install https://github.com/Lothiraldan/swagger-fuzzer/archive/master.zip
+    pip3 install https://github.com/Lothiraldan/swagger-fuzzer/archive/master.zip
 
 Point it to your swagger specification:
 


### PR DESCRIPTION
If using pip, it leads to the following:

```
$ pip install https://github.com/Lothiraldan/swagger-fuzzer/archive/master.zip --user --upgrade
...
$ swagger-fuzzer http://localhost:80/explorer/swagger.json
Traceback (most recent call last):
  File "/home/cadesalaberry/.local/bin/swagger-fuzzer", line 11, in <module>
    load_entry_point('swagger-fuzzer==0.1.0', 'console_scripts', 'swagger-fuzzer')()
  File "/home/cadesalaberry/.local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 567, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/cadesalaberry/.local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2612, in load_entry_point
    return ep.load()
  File "/home/cadesalaberry/.local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2272, in load
    return self.resolve()
  File "/home/cadesalaberry/.local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2278, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/cadesalaberry/.local/lib/python2.7/site-packages/swagger_fuzzer/swagger_fuzzer.py", line 5, in <module>
    from urllib.parse import urlparse, urlunparse
ImportError: No module named parse
```
